### PR TITLE
make: Remove directories in clean

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -177,7 +177,7 @@ quicktest:
 	  echo && echo "*** Quicktest was successful" && echo
 
 clean:
-	rm -f $(OBJDIR)/*.* $(DEPENDDIR)/*.* $(PATCH_PP) $(SHARCPATCH_PP)
+	rm -rf $(OBJDIR)/*.* $(DEPENDDIR)/*.* $(PATCH_PP) $(SHARCPATCH_PP)
 	for i in $(SUBDIRS) cil; do make -C $$i clean; done
 
 libclean:


### PR DESCRIPTION
On macosx, the output is a directory structure. So we add `-r` to `rm` to remove the
created directories.
