### PR TITLE
heapsafe: Use -m32 for 32-bit assembly

### DIFF
--- a/heapsafe-lib/linux/Makefile
+++ b/heapsafe-lib/linux/Makefile
@@ -2,6 +2,9 @@ CFLAGS=-I../../heapsafe-include -g -O3 --param max-inline-insns-single=1000 -DND
 
 all: bsd-_setjmp.o longjmp.o sigjmp.o clongjmp.o csigjmp.o
 
+bsd-_setjmp.o: bsd-_setjmp.S
+	$(CC) -c -m32 bsd-_setjmp.S
+
 longjmp.o: longjmp.c
 	$(CC) $(CFLAGS) -D__HS_NOCONCRC__ -c -o longjmp.o longjmp.c
 

--- a/heapsafe-lib/macosx-i386/Makefile
+++ b/heapsafe-lib/macosx-i386/Makefile
@@ -3,10 +3,10 @@ CFLAGS=-I../../heapsafe-include -g -O3 --param max-inline-insns-single=1000 -DND
 all: setjmp.o _setjmp.o csetjmp.o sigsetjmp.o conccsetjmp.o concsigsetjmp.o
 
 setjmp.o: setjmp.s
-	$(CC) -c -I. setjmp.s
+	$(CC) -c -m32 -I. setjmp.s
 
 _setjmp.o: _setjmp.s
-	$(CC) -c -I. _setjmp.s
+	$(CC) -c -m32 -I. _setjmp.s
 
 csetjmp.o: csetjmp.c
 	$(CC) $(CFLAGS) -D__HS_NOCONCRC__ -c -o csetjmp.o csetjmp.c


### PR DESCRIPTION
These functions are written with 32-bit i386 assembly, so we restrict the
compilation to 32-bit.
