### PR TITLE
heapsafe: Only declare mem* if they are present

### DIFF
--- a/heapsafe-include/heapsafe.h
+++ b/heapsafe-include/heapsafe.h
@@ -215,9 +215,12 @@ void __builtin_hs_clear(void *p);
  * Warnings for memcpy and friends
  * -------------------------------------------------------------------------*/
 
+#ifdef HAVE_STRING_H
 void *memcpy(void *to, const void *from, size_t s) hs_untyped;
 void *memmove(void *to, const void *from, size_t s) hs_untyped;
 void *memset(void *to, int c, size_t s) hs_untyped;
+#endif
+
 void bcopy(const void *from, void *to, size_t s) hs_untyped;
 void bzero(void *to, size_t s) hs_untyped;
 


### PR DESCRIPTION
Newer versions of compilers (e.g. clang and gcc) declare some standard library
functions as macros. If these mem\* prototypes are given, the compiler applies
the macro and then subsequently produces a lot of strange syntax errors.

The quick solution used here is to only declare the prototypes if they are not
macros. This is not the best solution. Rather, we would like to somehow use the
warnings of hs_untyped even if the macros are used. But this will need some
thought.
